### PR TITLE
cleanup & fixes

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -45,6 +45,9 @@ async def on_message(message):
     if message.author == client.user:
         return
 
+    if not message.content.startswith("$"):
+        return
+
     if message.content.startswith('$hello'):
         print("Ran Hello.")
         await message.reply('Hello!')
@@ -68,37 +71,36 @@ async def on_message(message):
         res = neofetch.go()
         await mymsg.edit(content="```ansi\n"+res+"\n```")
     else:
-        if message.content.startswith("$"):
-            shSc = message.content
-            shSc = shSc.replace("$", " ")
+        shSc = message.content
+        shSc = shSc[1:]
 
-            # Check if banned
-            # for word in bannedCmds:
-            #    if word in message.content:
-            #        await message.channel.send("Command "+word+" is banned")
-            #        return
-            try:
-                myMsg = await message.reply("Please wait...")
-                f = open("/tmp/wiiBot_cmd", "w")
-                f.write(shSc)
-                f.close()
+        # Check if banned
+        # for word in bannedCmds:
+        #    if word in message.content:
+        #        await message.channel.send("Command "+word+" is banned")
+        #        return
+        try:
+            myMsg = await message.reply("Please wait...")
+            f = open("/tmp/wiiBot_cmd", "w")
+            f.write(shSc)
+            f.close()
 
-                shRe = subprocess.run("su -c 'bash /tmp/wiiBot_cmd' discord", shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                if len(shRe.stdout) > 3970:
-                    await myMsg.edit(content="**Warning**: Command output too much text, truncating\n```ansi\n"+shRe.stdout[0:1900]+"\n```\n")
-                    await myMsg.reply("```ansi\n"+shRe.stdout[1901:3800]+"\n```\n")
-                elif len(shRe.stdout) > 1970:
-                    await myMsg.edit(content="```ansi\n"+shRe.stdout[0:1900]+"\n```\n")
-                    await myMsg.reply("```ansi\n"+shRe.stdout[1901:-1]+"\n```\n")
-                else:
-                    await myMsg.edit(content="```ansi\n"+shRe.stdout+"\n```\n")
+            shRe = subprocess.run("su -c 'bash /tmp/wiiBot_cmd' discord", shell=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            if len(shRe.stdout) > 3970:
+                await myMsg.edit(content="**Warning**: Command output too much text, truncating\n```ansi\n"+shRe.stdout[0:1900]+"\n```\n")
+                await myMsg.reply("```ansi\n"+shRe.stdout[1901:3800]+"\n```\n")
+            elif len(shRe.stdout) > 1970:
+                await myMsg.edit(content="```ansi\n"+shRe.stdout[0:1900]+"\n```\n")
+                await myMsg.reply("```ansi\n"+shRe.stdout[1901:-1]+"\n```\n")
+            else:
+                await myMsg.edit(content="```ansi\n"+shRe.stdout+"\n```\n")
 
-            except Exception as e:
-                content = "```\n"+f"We fucked up: {e}"+"\n```"
-                if myMsg:
-                    await myMsg.edit(content=content)
-                else:
-                    await message.channel.send(content)
+        except Exception as e:
+            content = "```\n"+f"We fucked up: {e}"+"\n```"
+            if myMsg:
+                await myMsg.edit(content=content)
+            else:
+                await message.channel.send(content)
 # Get token
 tok = ""
 with open("token.txt", "r") as tf:


### PR DESCRIPTION
- Immediately give up if the message doesn't start with a dollar sign
- Remove that check from the command parser, since it's moved
- Fix the code to get rid of the leading dollar sign